### PR TITLE
Correct command order + build.bat file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - 构建
   1. 准备编译环境：**v2版AutoHotKey_H**、**Ahk2Exe**、**C++ MinGW-w64**
   2. 下载源代码：`git clone https://github.com/Angels-D/TroveAuto.git && cd TroveAuto`
-  3. 编译DLL依赖：`g++ -shared -static -Os -Wall -lgdi32 -o Module.dll -x c++ ./libs/Module.hpp`
+  3. 编译DLL依赖：`g++ -shared -static -Os -Wall -o Module.dll -x c++ ./libs/Module.hpp -lgdi32`
   4. 编译ahk脚本：`<Ahk2Exe路径>/Ahk2Exe.exe /compress 2 /base <AHK_Hv2路径>/AutoHotkey64.exe /in ./TroveAuto.ahk`
      > - `/compress 2` 使用UPX进行代码压缩
      > - 注意文件字符编码格式
@@ -62,7 +62,7 @@
 - Build
   1. Prepare the build environment: **AutoHotKey_H v2**, **Ahk2Exe**, **C++ MinGW-w64**
   2. Download the source code: `git clone https://github.com/Angels-D/TroveAuto.git && cd TroveAuto`
-  3. Compile the DLL dependency: `g++ -shared -static -Os -Wall -lgdi32 -o Module.dll -x c++ ./libs/Module.hpp`
+  3. Compile the DLL dependency: `g++ -shared -static -Os -Wall -o Module.dll -x c++ ./libs/Module.hpp -lgdi32`
   4. Compile the AHK script: `<Ahk2Exe path>/Ahk2Exe.exe /compress 2 /base <AHK_Hv2 path>/AutoHotkey64.exe /in ./TroveAuto.ahk`
      > - `/compress 2` uses UPX for code compression
      > - Note the file character encoding format

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,10 @@
+@echo off
+echo === Compile Module.hpp into Module.dll ===
+g++ -shared -static -Os -Wall -o Module.dll -x c++ ./libs/Module.hpp -lgdi32
+
+echo === Compile TroveAuto.ahk into .exe ===
+"C:\Program Files\AutoHotkey\Compiler\Ahk2Exe.exe" /compress 2 /base "C:\Program Files\AutoHotkey\v2\AutoHotkey64.exe" /in .\TroveAuto.ahk
+
+echo === DONE ===
+
+pause


### PR DESCRIPTION
## 1. Modified the command order as it is currently not building.
### Error:
`(.text$_ZN15CopyrightNotice10DialogProcEP6HWND__jyx[_ZN15CopyrightNotice10DialogProcEP6HWND__jyx]+0x166): undefined reference to __imp_SetBkColor'`
`(.text$_ZN15CopyrightNotice10DialogProcEP6HWND__jyx[_ZN15CopyrightNotice10DialogProcEP6HWND__jyx]+0x178): undefined reference to __imp_GetStockObject'`

### Why does it happen?
"Order matters in GCC/MinGW - Libraries (-lgdi32) must come after the object/source files they resolve symbols for."

### FIX:
- Moved `-lgdi32` after `Module.hpp`

## 2. Created `build.bat` file for easier and faster builds.
### How it works?
- It uses the 2 command lines mentioned in the `README.md` file using the correct order

### AHK paths?
- It uses the default AHK installation folder to find the `Ahk2Exe.exe` and `AutoHotkey64.exe`. *You can easily modify the paths as needed in the `build.bat` file.